### PR TITLE
Adding Bouffalo SDK Framework to pinecone board

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,9 +7,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
         python-version: [3.7]
         example:
+          - "examples/arduino-blinky"
+          - "examples/boufallo-sdk-hello"
           - "examples/freedom-e-sdk_freertos-blinky"
           - "examples/freedom-e-sdk_freertos-blinky-system-view"
           - "examples/freedom-e-sdk_freertos-pmp-blinky"

--- a/boards/pinecone.json
+++ b/boards/pinecone.json
@@ -21,7 +21,8 @@
     "qemu_machine": "sifive_e"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "bouffalo"
   ],
   "name": "PineCone (BL602)",
   "upload": {

--- a/builder/frameworks/bouffalo.py
+++ b/builder/frameworks/bouffalo.py
@@ -1,0 +1,40 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+
+Bouffalo SDK
+
+
+"""
+
+import sys
+from os.path import join, isfile
+
+from SCons.Script import DefaultEnvironment, SConscript
+
+env = DefaultEnvironment()
+mcu = env.BoardConfig().get("build.mcu")
+core = env.BoardConfig().get("build.core", "")
+
+if core == "bouffalo":
+    build_script = join(
+        env.PioPlatform().get_package_dir("framework-bouffalo-sdk"),
+        "tools", "platformio", "platformio-build.py")
+
+if not isfile(build_script):
+    sys.stderr.write("Error: Missing PlatformIO build script %s!\n" % build_script)
+    env.Exit(1)
+
+SConscript(build_script)

--- a/examples/arduino-blinky/.gitignore
+++ b/examples/arduino-blinky/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/arduino-blinky/include/README
+++ b/examples/arduino-blinky/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/examples/arduino-blinky/lib/README
+++ b/examples/arduino-blinky/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/examples/arduino-blinky/platformio.ini
+++ b/examples/arduino-blinky/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:pinecone_bl602]
+[env:pinecone]
 platform = sifive
 board = pinecone
 framework = arduino

--- a/examples/arduino-blinky/platformio.ini
+++ b/examples/arduino-blinky/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:pinecone_bl602]
+platform = sifive
+board = pinecone
+framework = arduino

--- a/examples/arduino-blinky/src/main.cpp
+++ b/examples/arduino-blinky/src/main.cpp
@@ -1,0 +1,19 @@
+#include <Arduino.h>
+
+//LED pins for on-board RGB LED
+//17 = R, 14 = G, B = 11
+//schematics for "Pine 64" board: https://files.pine64.org/doc/Pinenut/Pine64%20BL602%20EVB%20Schematic%20ver%201.1.pdf 
+//if you're working with a DL-BL10 board (https://www.analoglamb.com/product/bl602-risc-v-wifi-bt-board-dt-bl10/)
+//there is no on-board LED, connect one to GPIO17 ("D17").
+#define LED_PIN 17
+
+void setup() { 
+    pinMode(LED_PIN, OUTPUT);
+}
+
+void loop() {
+    delay(500);
+    digitalWrite(LED_PIN, HIGH);
+    delay(500);
+    digitalWrite(LED_PIN, LOW);
+}

--- a/examples/arduino-blinky/test/README
+++ b/examples/arduino-blinky/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html

--- a/examples/boufallo-sdk-hello/.gitignore
+++ b/examples/boufallo-sdk-hello/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/boufallo-sdk-hello/include/README
+++ b/examples/boufallo-sdk-hello/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/examples/boufallo-sdk-hello/lib/README
+++ b/examples/boufallo-sdk-hello/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/examples/boufallo-sdk-hello/platformio.ini
+++ b/examples/boufallo-sdk-hello/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:pinecone]
-platform = sifive.git
+platform = sifive
 board = pinecone
 framework = bouffalo
 build_flags = -v

--- a/examples/boufallo-sdk-hello/platformio.ini
+++ b/examples/boufallo-sdk-hello/platformio.ini
@@ -1,0 +1,15 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:pinecone]
+platform = sifive.git
+board = pinecone
+framework = bouffalo
+build_flags = -v

--- a/examples/boufallo-sdk-hello/src/main.cpp
+++ b/examples/boufallo-sdk-hello/src/main.cpp
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+extern "C" void main(void)
+{
+    printf("Hello World!\n");
+}

--- a/examples/boufallo-sdk-hello/test/README
+++ b/examples/boufallo-sdk-hello/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html

--- a/platform.json
+++ b/platform.json
@@ -83,8 +83,8 @@
     "framework-bouffalo-sdk": {
       "type": "framework",
       "optional": true,
-      "owner": "jsaiko",
-      "version": "https://github.com/jsaiko/framework-bouffalo-sdk.git"
+      "owner": "Community-BL-IOT",
+      "version": "https://github.com/Community-BL-IOT/framework-bouffalo-sdk.git"
     },
     "tool-bl60x-flash": {
       "optional": true,

--- a/platform.json
+++ b/platform.json
@@ -73,6 +73,12 @@
       "owner": "maxgerhardt",
       "version": "https://github.com/maxgerhardt/pio-bl-iot-sdk-arduino.git"
     },
+    "framework-bouffalo-sdk": {
+      "type": "framework",
+      "optional": true,
+      "owner": "jsaiko",
+      "version": "https://github.com/jsaiko/framework-bouffalo-sdk.git"
+    },
     "tool-bl60x-flash": {
       "optional": true,
       "type": "uploader",

--- a/platform.json
+++ b/platform.json
@@ -71,14 +71,14 @@
     "framework-arduinobouffalo": {
       "type": "framework",
       "optional": true,
-      "owner": "maxgerhardt",
-      "version": "https://github.com/maxgerhardt/ArduinoCore-bouffalo"
+      "owner": "Community-BL-IOT",
+      "version": "https://github.com/Community-BL-IOT/ArduinoCore-bouffalo"
     },
     "framework-bl-iot-sdk-arduino": {
       "type": "framework",
       "optional": true,
-      "owner": "maxgerhardt",
-      "version": "https://github.com/maxgerhardt/pio-bl-iot-sdk-arduino.git"
+      "owner": "Community-BL-IOT",
+      "version": "https://github.com/Community-BL-IOT/pio-bl-iot-sdk-arduino.git"
     },
     "framework-bouffalo-sdk": {
       "type": "framework",
@@ -89,8 +89,8 @@
     "tool-bl60x-flash": {
       "optional": true,
       "type": "uploader",
-      "owner": "maxgerhardt",
-      "version": "https://github.com/maxgerhardt/pio-bl60x-flash.git"
+      "owner": "Community-BL-IOT",
+      "version": "https://github.com/Community-BL-IOT/pio-bl60x-flash.git"
     },
     "tool-openocd-riscv": {
       "optional": true,

--- a/platform.json
+++ b/platform.json
@@ -41,6 +41,13 @@
       "description": "Arduino Wiring-based Framework allows writing cross-platform software to control devices attached to a wide range of Arduino boards to create all kinds of creative coding, interactive objects, spaces or physical experiences",
       "homepage": "https://github.com/pine64/ArduinoCore-bouffalo",
       "title": "Arduino"
+    },
+    "bouffalo": {
+      "package": "framework-bouffalo-sdk",
+      "script": "builder/frameworks/bouffalo.py",
+      "description": "Bouffalolab bl_iot_sdk. Support BL602 Wi-Fi/BLE Combo RISC-V based Chip and BL70X Zigbee/BLE RISC-V based Chip.",
+      "homepage": "https://pine64.github.io/bl602-docs",
+      "title": "Bouffalo SDK"
     }
   },
   "packages": {


### PR DESCRIPTION
These changes add support for the Bouffalo SDK framework on pinecone and BL602 boards.